### PR TITLE
Refactor to ES2015

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,6 @@
 {
   "bitwise": false,
   "maxcomplexity": 10,
-  "expr": true
+  "expr": true,
+  "esversion": 6
 }

--- a/lib/Bap.js
+++ b/lib/Bap.js
@@ -1,12 +1,12 @@
-var vent = require('./utils/vent');
-var Model = require('./Model');
-var Clock = require('./Clock');
-var LoadingState = require('./LoadingState');
-var numberInRangeType = require('./types/numberInRange');
+const vent = require('./utils/vent');
+const Model = require('./Model');
+const Clock = require('./Clock');
+const LoadingState = require('./LoadingState');
+const numberInRangeType = require('./types/numberInRange');
 
 require('./utils/performanceTimePolyfill')();
 
-var Bap = Model.extend({
+const Bap = Model.extend({
 
   type: 'bap',
 
@@ -34,7 +34,7 @@ var Bap = Model.extend({
   }
 });
 
-var constructors = {
+const constructors = {
   'Kit': require('./Kit'),
   'Slot': require('./Slot'),
   'Layer': require('./Layer'),
@@ -54,27 +54,25 @@ var constructors = {
   'PingPong': require('./effects/PingPongDelay')
 };
 
-function applyToConstructor (constructor, argArray) {
-  var args = [null].concat(argArray);
-  var factoryFunction = constructor.bind.apply(constructor, args);
+function applyToConstructor(constructor, argArray) {
+  const args = [null].concat(argArray);
+  const factoryFunction = constructor.bind.apply(constructor, args);
   return new factoryFunction();
 }
 
-Object.keys(constructors).forEach(function (name) {
-  var Ctor = constructors[name];
+Object.keys(constructors).forEach(name => {
+  const Ctor = constructors[name];
   Bap.prototype[name] = Ctor;
   Bap.prototype[name.toLowerCase()] = function () {
     return applyToConstructor(Ctor, [].slice.call(arguments));
   };
 });
 
-Bap.prototype.new = function () {
+Bap.prototype.new = () => {
   vent.reset();
   return new Bap();
 };
 
-Bap.pitchByRatio = function(ratio) {
-    return 12 * Math.log2(ratio);
-};
+Bap.pitchByRatio = ratio => 12 * Math.log2(ratio);
 
 module.exports = Bap;

--- a/lib/BufferHelper.js
+++ b/lib/BufferHelper.js
@@ -1,17 +1,17 @@
-var Model = require('./Model');
-var memoize = require('meemo');
-var utils = require('audio-buffer-utils');
+const Model = require('./Model');
+const memoize = require('meemo');
+const utils = require('audio-buffer-utils');
 
-var BufferHelper = Model.extend({
+const BufferHelper = Model.extend({
   type: 'bufferHelper'
 });
 
 BufferHelper.silentTailSize = 250;
 
-BufferHelper.trimStart = function (buffer, channel) {
-  var data = buffer.getChannelData(channel);
-  var didFindZeroCrossing = false;
-  var index = 0;
+BufferHelper.trimStart = (buffer, channel) => {
+  const data = buffer.getChannelData(channel);
+  let didFindZeroCrossing = false;
+  let index = 0;
 
   while (!didFindZeroCrossing && index < buffer.length) {
     if (data[index] > 0) {
@@ -24,10 +24,10 @@ BufferHelper.trimStart = function (buffer, channel) {
   }
 };
 
-BufferHelper.trimEnd = function (buffer, channel) {
-  var data = buffer.getChannelData(channel);
-  var didFindZeroCrossing = false;
-  var index = buffer.length - 1;
+BufferHelper.trimEnd = (buffer, channel) => {
+  const data = buffer.getChannelData(channel);
+  let didFindZeroCrossing = false;
+  let index = buffer.length - 1;
 
   while (!didFindZeroCrossing && index >= 0) {
     if (data[index] < 0) {
@@ -41,17 +41,17 @@ BufferHelper.trimEnd = function (buffer, channel) {
 };
 
 // http://noisehack.com/custom-audio-effects-javascript-web-audio-api/
-BufferHelper.bitcrush = function (buffer, channel, params) {
-  var data = buffer.getChannelData(channel);
-  var bits = params.bitcrush;
-  var normfreq = (params.bitcrushFrequency - 20) / 22030;
-  var mix = (params.bitcrushMix || 50) / 100;
-  var step = Math.pow(1/2, bits);
-  var phaser = 0;
-  var last = 0;
-  var chunk;
+BufferHelper.bitcrush = (buffer, channel, {bitcrush, bitcrushFrequency, bitcrushMix}) => {
+  const data = buffer.getChannelData(channel);
+  const bits = bitcrush;
+  const normfreq = (bitcrushFrequency - 20) / 22030;
+  const mix = (bitcrushMix || 50) / 100;
+  const step = Math.pow(1/2, bits);
+  let phaser = 0;
+  let last = 0;
+  let chunk;
 
-  for (var i = 0; i < buffer.length; i++) {
+  for (let i = 0; i < buffer.length; i++) {
     phaser += normfreq;
     if (phaser >= 1.0) {
         phaser -= 1.0;
@@ -61,8 +61,8 @@ BufferHelper.bitcrush = function (buffer, channel, params) {
     chunk = last;
 
     if (mix !== 1) {
-      var wet = chunk * mix;
-      var dry = data[i] * (1 - mix);
+      const wet = chunk * mix;
+      const dry = data[i] * (1 - mix);
       chunk = wet + dry;
     }
 
@@ -70,9 +70,9 @@ BufferHelper.bitcrush = function (buffer, channel, params) {
   }
 };
 
-BufferHelper.getCopyLength = function (params, buffer) {
-  var length = Math.floor(buffer.sampleRate * params.length);
-  var offset = Math.floor(buffer.sampleRate * params.offset);
+BufferHelper.getCopyLength = (params, buffer) => {
+  let length = Math.floor(buffer.sampleRate * params.length);
+  const offset = Math.floor(buffer.sampleRate * params.offset);
   if (params.loop) {
     length = Math.floor(buffer.sampleRate * params.loop);
   }
@@ -81,80 +81,88 @@ BufferHelper.getCopyLength = function (params, buffer) {
   return length;
 };
 
-BufferHelper.getChannelCount = function (params, buffer) {
-  var singles = ['left', 'right', 'diff', 'merge'];
-  if (~singles.indexOf(params.channel)) {
+BufferHelper.getChannelCount = ({channel}, {numberOfChannels}) => {
+  const singles = ['left', 'right', 'diff', 'merge'];
+  if (~singles.indexOf(channel)) {
     return 1;
   }
-  return buffer.numberOfChannels;
+  return numberOfChannels;
 };
 
-BufferHelper.getSourceChannel = function (params, original) {
-  if (original.numberOfChannels === 1) return 0;
-  else if (params.channel === 'left') return 0;
-  else if (params.channel === 'right') return 1;
+BufferHelper.getSourceChannel = ({channel}, {numberOfChannels}) => {
+  if (numberOfChannels === 1) return 0;
+  else if (channel === 'left') return 0;
+  else if (channel === 'right') return 1;
   else return null;
 };
 
-BufferHelper.getSourceStartIndex = function (params, buffer) {
-  var index = Math.floor(buffer.sampleRate * params.offset);
-  if (index >= buffer.length) throw new Error('Invalid buffer source start index: params.offset is greater or equal to original buffer length');
+BufferHelper.getSourceStartIndex = ({offset}, {sampleRate, length}) => {
+  const index = Math.floor(sampleRate * offset);
+  if (index >= length) throw new Error('Invalid buffer source start index: params.offset is greater or equal to original buffer length');
   return index;
 };
 
-BufferHelper.getTargetStartIndex = function (params) {
-  if (params.trimToZeroCrossingPoint && params.reverse && !params.loop) return BufferHelper.silentTailSize;
+BufferHelper.getTargetStartIndex = ({trimToZeroCrossingPoint, reverse, loop}) => {
+  if (trimToZeroCrossingPoint && reverse && !loop) return BufferHelper.silentTailSize;
   return 0;
 };
 
-BufferHelper.getRealLength = function (params, copyLength) {
-  if (params.trimToZeroCrossingPoint && !params.loop) return copyLength + BufferHelper.silentTailSize;
+BufferHelper.getRealLength = ({trimToZeroCrossingPoint, loop}, copyLength) => {
+  if (trimToZeroCrossingPoint && !loop) return copyLength + BufferHelper.silentTailSize;
   return copyLength;
 };
 
-BufferHelper.copyChannelData = function (originalBuffer, outputBuffer, sourceChannel, targetChannel, startIndex, targetStartIndex, copyLength) {
-  var input = originalBuffer.getChannelData(sourceChannel);
-  var output = outputBuffer.getChannelData(targetChannel);
-  var offset = targetStartIndex - startIndex;
+BufferHelper.copyChannelData = (
+  originalBuffer,
+  outputBuffer,
+  sourceChannel,
+  targetChannel,
+  startIndex,
+  targetStartIndex,
+  copyLength
+) => {
+  const input = originalBuffer.getChannelData(sourceChannel);
+  const output = outputBuffer.getChannelData(targetChannel);
+  const offset = targetStartIndex - startIndex;
 
-  for (var i = startIndex, max = startIndex + copyLength; i < max; i++) {
+  for (let i = startIndex, max = startIndex + copyLength; i < max; i++) {
     output[i + offset] = input[i];
   }
 };
 
-BufferHelper.diffChannelsData = function (originalBuffer, outputBuffer, startIndex, targetStartIndex, copyLength) {
-  var firstInput = originalBuffer.getChannelData(0);
-  var secondInput = originalBuffer.getChannelData(1);
-  var output = outputBuffer.getChannelData(0);
-  var offset = targetStartIndex - startIndex;
+BufferHelper.diffChannelsData = (originalBuffer, outputBuffer, startIndex, targetStartIndex, copyLength) => {
+  const firstInput = originalBuffer.getChannelData(0);
+  const secondInput = originalBuffer.getChannelData(1);
+  const output = outputBuffer.getChannelData(0);
+  const offset = targetStartIndex - startIndex;
 
-  for (var i = startIndex, max = startIndex + copyLength; i < max; i++) {
+  for (let i = startIndex, max = startIndex + copyLength; i < max; i++) {
     output[i + offset] = firstInput[i] - secondInput[i];
   }
 };
 
-BufferHelper.mergeChannelsData = function (originalBuffer, outputBuffer, startIndex, targetStartIndex, copyLength) {
-  var firstInput = originalBuffer.getChannelData(0);
-  var secondInput = originalBuffer.getChannelData(1);
-  var output = outputBuffer.getChannelData(0);
-  var offset = targetStartIndex - startIndex;
+BufferHelper.mergeChannelsData = (originalBuffer, outputBuffer, startIndex, targetStartIndex, copyLength) => {
+  const firstInput = originalBuffer.getChannelData(0);
+  const secondInput = originalBuffer.getChannelData(1);
+  const output = outputBuffer.getChannelData(0);
+  const offset = targetStartIndex - startIndex;
 
-  for (var i = startIndex, max = startIndex + copyLength; i < max; i++) {
+  for (let i = startIndex, max = startIndex + copyLength; i < max; i++) {
     output[i + offset] = firstInput[i] + secondInput[i];
   }
 };
 
-BufferHelper.makeBuffer = memoize(function (params, originalBuffer, context) {
+BufferHelper.makeBuffer = memoize((params, originalBuffer, context) => {
 
-  var start = new Date();
-  var sampleRate = originalBuffer.sampleRate;
-  var numberOfChannels = BufferHelper.getChannelCount(params, originalBuffer);
-  var sourceChannel = BufferHelper.getSourceChannel(params, originalBuffer);
-  var sourceStartIndex = BufferHelper.getSourceStartIndex(params, originalBuffer);
-  var targetStartIndex = BufferHelper.getTargetStartIndex(params);
-  var copyLength = BufferHelper.getCopyLength(params, originalBuffer);
-  var realLength = BufferHelper.getRealLength(params, copyLength);
-  var outputBuffer = context.createBuffer(numberOfChannels, realLength, sampleRate);
+  const start = new Date();
+  const sampleRate = originalBuffer.sampleRate;
+  const numberOfChannels = BufferHelper.getChannelCount(params, originalBuffer);
+  const sourceChannel = BufferHelper.getSourceChannel(params, originalBuffer);
+  const sourceStartIndex = BufferHelper.getSourceStartIndex(params, originalBuffer);
+  const targetStartIndex = BufferHelper.getTargetStartIndex(params);
+  const copyLength = BufferHelper.getCopyLength(params, originalBuffer);
+  const realLength = BufferHelper.getRealLength(params, copyLength);
+  const outputBuffer = context.createBuffer(numberOfChannels, realLength, sampleRate);
 
   if (sourceChannel) {
     BufferHelper.copyChannelData(originalBuffer, outputBuffer, sourceChannel, 0, sourceStartIndex, targetStartIndex, copyLength);
@@ -166,7 +174,7 @@ BufferHelper.makeBuffer = memoize(function (params, originalBuffer, context) {
     BufferHelper.mergeChannelsData(originalBuffer, outputBuffer, sourceStartIndex, targetStartIndex, copyLength);
   }
   else {
-    for (var i = 0; i < originalBuffer.numberOfChannels; i++) {
+    for (let i = 0; i < originalBuffer.numberOfChannels; i++) {
       BufferHelper.copyChannelData(originalBuffer, outputBuffer, i, i, sourceStartIndex, targetStartIndex, copyLength);
     }
   }
@@ -175,7 +183,7 @@ BufferHelper.makeBuffer = memoize(function (params, originalBuffer, context) {
     utils.reverse(outputBuffer);
   }
 
-  for (var j = 0; j < numberOfChannels; j++) {
+  for (let j = 0; j < numberOfChannels; j++) {
     if (params.trimToZeroCrossingPoint && !params.loop) {
       BufferHelper.trimStart(outputBuffer, j);
       BufferHelper.trimEnd(outputBuffer, j);
@@ -187,13 +195,13 @@ BufferHelper.makeBuffer = memoize(function (params, originalBuffer, context) {
 
   return outputBuffer;
 }, function memoizeKey (params, buffer, context) {
-  var hash = buffer.uid;
+  let hash = buffer.uid;
   [
     'length', 'offset', 'loop', 'reverse',
     'trimEndToZeroCrossingPoint', 'channel',
     'bitcrush', 'bitcrushFrequency', 'bitcrushMix',
-  ].forEach(function (key) {
-    hash += ('//' + key + ':' + params[key]);
+  ].forEach(key => {
+    hash += (`//${key}:${params[key]}`);
   });
   return hash;
 });

--- a/lib/Channel.js
+++ b/lib/Channel.js
@@ -1,16 +1,16 @@
-var Model = require('./Model');
-var Note = require('./Note');
-var Collection = require('./Collection');
-var volumeParams = require('./mixins/volumeParams');
-var connectable = require('./mixins/connectable');
-var bypassable = require('./mixins/bypassable');
-var expressions = require('dilla-expressions');
+const Model = require('./Model');
+const Note = require('./Note');
+const Collection = require('./Collection');
+const volumeParams = require('./mixins/volumeParams');
+const connectable = require('./mixins/connectable');
+const bypassable = require('./mixins/bypassable');
+const expressions = require('dilla-expressions');
 
-var NotesCollection = Collection.extend({
+const NotesCollection = Collection.extend({
   model: Note
 });
 
-var Channel = Model.extend(volumeParams, bypassable, {
+const Channel = Model.extend(volumeParams, bypassable, {
 
   type: 'channel',
 
@@ -41,29 +41,27 @@ var Channel = Model.extend(volumeParams, bypassable, {
   },
 
   add: function () {
-    var notes = [].slice.call(arguments).map(function (raw) {
-      return raw instanceof Note ? raw : Note.fromRaw(raw);
-    });
+    const notes = [].slice.call(arguments).map(raw => raw instanceof Note ? raw : Note.fromRaw(raw));
     this.rawNotes.add(notes);
     return this;
   },
 
   notes: function (bar, beat, tick) {
     if (!bar) return this.expandedNotes.models.slice();
-    var cache = this._cache;
-    var beats = cache[bar];
+    const cache = this._cache;
+    const beats = cache[bar];
     if (!beat) return (beats && beats['*'] || []).slice();
-    var ticks = beats && beats[beat];
+    const ticks = beats && beats[beat];
     if (!tick) return (ticks && ticks['*'] || []).slice();
     return (ticks && ticks[tick] || []).slice();
   },
 
   transforms: function (note) {
     if (!note || !(note instanceof Note)) throw new Error('Invalid argument: note is not an instance of bap.note');
-    var pattern = this.collection && this.collection.parent;
+    const pattern = this.collection && this.collection.parent;
 
-    var transforms = [];
-    [note, this, pattern].forEach(function (source) {
+    const transforms = [];
+    [note, this, pattern].forEach(source => {
       if (source && source.transform && typeof source.transform === 'function') {
         transforms.push(source.transform);
       }
@@ -71,18 +69,18 @@ var Channel = Model.extend(volumeParams, bypassable, {
 
     if (!transforms.length) return false;
 
-    return function (note) {
-      transforms.forEach(function (fn) {
+    return note => {
+      transforms.forEach(fn => {
         fn(note);
       });
     };
   },
 
   _onAddExpandedNote: function (note) {
-    var cache = this._cache;
-    var bar = note.bar;
-    var beat = note.beat;
-    var tick = note.tick;
+    const cache = this._cache;
+    const bar = note.bar;
+    const beat = note.beat;
+    const tick = note.tick;
 
     cache[bar] = cache[bar] || {};
     cache[bar]['*'] = cache[bar]['*'] || [];
@@ -95,48 +93,48 @@ var Channel = Model.extend(volumeParams, bypassable, {
   },
 
   _onRemoveExpandedNote: function (note) {
-    var cache = this._cache;
-    var bar = note.bar;
-    var beat = note.beat;
-    var tick = note.tick;
+    const cache = this._cache;
+    const bar = note.bar;
+    const beat = note.beat;
+    const tick = note.tick;
 
-    var barIndex = cache[bar]['*'].indexOf(note);
+    const barIndex = cache[bar]['*'].indexOf(note);
     cache[bar]['*'].splice(barIndex, 1);
-    var beatIndex = cache[bar][beat]['*'].indexOf(note);
+    const beatIndex = cache[bar][beat]['*'].indexOf(note);
     cache[bar][beat]['*'].splice(beatIndex, 1);
-    var tickIndex = cache[bar][beat][tick].indexOf(note);
+    const tickIndex = cache[bar][beat][tick].indexOf(note);
     cache[bar][beat][tick].splice(tickIndex, 1);
   },
 
   _onAddRawNote: function (note) {
-    var transform = this.transforms(note);
+    const transform = this.transforms(note);
 
     if (note.hasPlainPosition() && !transform) {
       note.original = note;
       return this.expandedNotes.add(note);
     }
 
-    var pattern = this.collection && this.collection.parent;
-    var options = {
+    const pattern = this.collection && this.collection.parent;
+    const options = {
       barsPerLoop: pattern && pattern.bars || 1,
       beatsPerBar: pattern && pattern.beatsPerBar || 4
     };
 
-    expressions([[note.position]], options).forEach(function (position) {
-      var expanded = note.with({ position: position[0] });
+    expressions([[note.position]], options).forEach(position => {
+      const expanded = note.with({ position: position[0] });
       expanded.original = note;
       transform && transform(expanded);
       this.expandedNotes.add(expanded);
-    }.bind(this));
+    });
   },
 
   _onRemoveRawNote: function (note) {
-    this.expandedNotes.models.slice().forEach(function (expanded) {
+    this.expandedNotes.models.slice().forEach(expanded => {
       if (note === expanded.original) {
         this.expandedNotes.remove(expanded);
         expanded.original = null;
       }
-    }.bind(this));
+    });
   },
 
   _onChangeRawNote: function (note) {

--- a/lib/Clock.js
+++ b/lib/Clock.js
@@ -1,18 +1,18 @@
-var PositionModel = require('./PositionModel');
-var Dilla = require('dilla');
-var instanceOfType = require('./types/instanceOfType');
-var debounce = require('lodash.debounce');
-var memoize = require('meemo');
+const PositionModel = require('./PositionModel');
+const Dilla = require('dilla');
+const instanceOfType = require('./types/instanceOfType');
+const debounce = require('lodash.debounce');
+const memoize = require('meemo');
 
-var inited = false;
+let inited = false;
 function init (context) {
   inited = true;
-  var source = context.createBufferSource();
+  const source = context.createBufferSource();
   source.buffer = context.createBuffer(1, 22050, 44100);
   source.start(0);
 }
 
-var Clock = PositionModel.extend({
+const Clock = PositionModel.extend({
 
   type: 'clock',
 
@@ -67,9 +67,9 @@ var Clock = PositionModel.extend({
     }
 
     if (!this._canStartPlaying()) {
-      return setTimeout(function () {
+      return setTimeout(() => {
         this.start(sequence);
-      }.bind(this), 10);
+      }, 10);
     }
 
     if (sequence) {
@@ -123,17 +123,17 @@ var Clock = PositionModel.extend({
   },
 
   _lookaheadSteps: function () {
-    var bar = this.bar || 1;
-    var beat = this.beat || 1;
-    var beatsPerBar = this.sequence && this.sequence.beatsPerBar || 4;
-    var bars = this.sequence && this.sequence.bars || 1;
-    var isLooping = this.sequence && this.sequence.loop;
-    var handler = isLooping && bars <= 17 ? Clock.possibleSteps : Clock.uncachedPossibleSteps;
+    const bar = this.bar || 1;
+    const beat = this.beat || 1;
+    const beatsPerBar = this.sequence && this.sequence.beatsPerBar || 4;
+    const bars = this.sequence && this.sequence.bars || 1;
+    const isLooping = this.sequence && this.sequence.loop;
+    const handler = isLooping && bars <= 17 ? Clock.possibleSteps : Clock.uncachedPossibleSteps;
     return handler(bar, beat, bars, beatsPerBar);
   },
 
   _onChangePlaying: function () {
-    var method = this.playing ? 'start' : 'pause';
+    const method = this.playing ? 'start' : 'pause';
     this[method]();
     if (this.sequence) {
       this.sequence.playing = this.playing;
@@ -141,7 +141,7 @@ var Clock = PositionModel.extend({
   },
 
   _onChangeSequence: function () {
-    var old = this._previousAttributes.sequence;
+    const old = this._previousAttributes.sequence;
     if (old) {
       this.stopListening(old);
     }
@@ -166,8 +166,8 @@ var Clock = PositionModel.extend({
     this.engine.setTempo(this.tempo);
   },
 
-  _onEngineTick: function (tick) {
-    if (!this.playing || tick.position === '0.0.00') {
+  _onEngineTick: function({position}) {
+    if (!this.playing || position === '0.0.00') {
       return;
     }
     else if (this._stopByFold) {
@@ -175,19 +175,19 @@ var Clock = PositionModel.extend({
       this.tick = 96;
     }
     else {
-      this.position = tick.position;
+      this.position = position;
       this.tempo = this.engine.tempo();
     }
   },
 
-  _onEngineStep: function (step) {
+  _onEngineStep: function({id, position, time}) {
     if (!this.playing || !this.sequence) {
       return;
     }
-    else if (step.id === 'lookahead' && !this._foldingOverLoop(step.position)) {
-      this._updateTempo(step.position);
-      this._queueNotesForStep(step.position, step.time);
-      this._lastQueuedPosition = step.position;
+    else if (id === 'lookahead' && !this._foldingOverLoop(position)) {
+      this._updateTempo(position);
+      this._queueNotesForStep(position, time);
+      this._lastQueuedPosition = position;
     }
   },
 
@@ -196,10 +196,10 @@ var Clock = PositionModel.extend({
       this.tempo = 120;
     }
     else if (position && this.sequence.tempoAt) {
-      var fragments = Clock.fragments(position);
-      var ticks = Clock.ticksForTempoChange(this.tempo);
-      var shouldLookAhead = fragments[2] >= (96 - ticks) && fragments[1] === this.sequence.beatsPerBar;
-      var checkBar = shouldLookAhead ? fragments[0] + 1 : fragments[0];
+      const fragments = Clock.fragments(position);
+      const ticks = Clock.ticksForTempoChange(this.tempo);
+      const shouldLookAhead = fragments[2] >= (96 - ticks) && fragments[1] === this.sequence.beatsPerBar;
+      let checkBar = shouldLookAhead ? fragments[0] + 1 : fragments[0];
       if (checkBar > this.sequence.bars && this.sequence.loop) {
         checkBar = 1;
       }
@@ -211,8 +211,8 @@ var Clock = PositionModel.extend({
   },
 
   _foldingOverLoop: function (position) {
-    var previous = Clock.paddedPosition(this._lastQueuedPosition);
-    var next = Clock.paddedPosition(position);
+    const previous = Clock.paddedPosition(this._lastQueuedPosition);
+    const next = Clock.paddedPosition(position);
     if (next < previous) {
       this.looped++;
     }
@@ -223,13 +223,13 @@ var Clock = PositionModel.extend({
   _queueNotesForStep: function (position, time) {
     if (!this.sequence) { return; }
 
-    var fragments = Clock.fragments(position);
-    var notes = this.sequence.notes(fragments[0], fragments[1], fragments[2]);
+    const fragments = Clock.fragments(position);
+    let notes = this.sequence.notes(fragments[0], fragments[1], fragments[2]);
     notes = Array.isArray(notes) ? notes : notes[fragments[0]];
 
-    var step = typeof this.step === 'function' ? this.step : null;
+    const step = typeof this.step === 'function' ? this.step : null;
 
-    notes.forEach(function (note) {
+    notes.forEach(note => {
       if (!step || step && step(note, time) !== false) {
         note.start(time);
       }
@@ -244,15 +244,15 @@ var Clock = PositionModel.extend({
   }
 });
 
-Clock.uncachedPossibleSteps = function (bar, beat, bars, beats) {
+Clock.uncachedPossibleSteps = (bar, beat, bars, beats) => {
 
-  var steps = new Array(192);
-  var index = 0;
+  const steps = new Array(192);
+  let index = 0;
 
   function push () {
-    var tick = 0;
+    let tick = 0;
     while (++tick < 97) {
-      steps[index] = [[bar, beat, tick < 10 ? '0' + tick : tick].join('.')];
+      steps[index] = [[bar, beat, tick < 10 ? `0${tick}` : tick].join('.')];
       index++;
     }
   }
@@ -273,10 +273,10 @@ Clock.possibleSteps = memoize(Clock.uncachedPossibleSteps, function () {
   return [].slice.call(arguments).join('//');
 });
 
-Clock.ticksForTempoChange = memoize(function (tempo) {
-  var rate = tempo / 100;
-  var multiplier = rate > 2 ? rate - 1 : 1;
-  var ticks = Math.ceil((rate * multiplier) * 4);
+Clock.ticksForTempoChange = memoize(tempo => {
+  const rate = tempo / 100;
+  const multiplier = rate > 2 ? rate - 1 : 1;
+  const ticks = Math.ceil((rate * multiplier) * 4);
   return ticks < 2 ? 2 : ticks;
 });
 

--- a/lib/Collection.js
+++ b/lib/Collection.js
@@ -1,12 +1,12 @@
-var context = require('./utils/context');
-var Collection = require('ampersand-collection');
+const context = require('./utils/context');
+const Collection = require('ampersand-collection');
 
 module.exports = Collection.extend({
 
   nextId: function () {
 
-    var nextPossible = 0;
-    var id;
+    let nextPossible = 0;
+    let id;
     while (!id) {
       if (!this.get(++nextPossible)) {
         id = nextPossible;

--- a/lib/Effect.js
+++ b/lib/Effect.js
@@ -1,9 +1,9 @@
 require('es6-object-assign').polyfill();
 
-var Model = require('./Model');
-var numberInRangeType = require('./types/numberInRange');
+const Model = require('./Model');
+const numberInRangeType = require('./types/numberInRange');
 
-var Tuna, tuna;
+let Tuna, tuna;
 if (global.window) {
   Tuna = require('tunajs');
 }
@@ -17,7 +17,7 @@ module.exports = Model.extend({
 
   props: {
     bypass: ['boolean', true, false],
-    nodes: ['object', true, function () { return {}; }]
+    nodes: ['object', true, () => ({})]
   },
 
   dataTypes: {
@@ -33,20 +33,20 @@ module.exports = Model.extend({
   },
 
   createNode: function () {
-    throw new Error('Required method "createNode" is not implemented for ' + this.cid);
+    throw new Error(`Required method "createNode" is not implemented for ${this.cid}`);
   },
 
   configureNode: function (node) {
-    throw new Error('Required method "configureNode" is not implemented for ' + this.cid);
+    throw new Error(`Required method "configureNode" is not implemented for ${this.cid}`);
   },
 
   combineNodes: function (input, output) {
 
-    input.connect = function (destination) {
+    input.connect = destination => {
       output.connect(destination);
     };
 
-    input.disconnect = function () {
+    input.disconnect = () => {
       output.disconnect();
     };
 
@@ -54,20 +54,20 @@ module.exports = Model.extend({
   },
 
   getDestinationId: function (destination) {
-    var json = this.toJSON();
+    const json = this.toJSON();
     delete json.nodes;
     delete json.revision;
     delete json.bypass;
-    var params = JSON.stringify(json);
-    return destination + '//' + params;
+    const params = JSON.stringify(json);
+    return `${destination}//${params}`;
   },
 
   getNode: function (destination) {
 
-    var nodes = this.nodes;
+    const nodes = this.nodes;
 
-    var destinationId = this.getDestinationId(destination);
-    var node = nodes[destinationId];
+    const destinationId = this.getDestinationId(destination);
+    let node = nodes[destinationId];
 
     if (!node) {
       node = nodes[destinationId] = this.createNode();

--- a/lib/Kit.js
+++ b/lib/Kit.js
@@ -1,19 +1,19 @@
-var Model = require('./Model');
-var Slot = require('./Slot');
-var Collection = require('./Collection');
-var overloadedAccessor = require('./mixins/overloadedAccessor');
-var triggerParams = require('./mixins/triggerParams');
-var volumeParams = require('./mixins/volumeParams');
-var connectable = require('./mixins/connectable');
-var bypassable = require('./mixins/bypassable');
-var instanceOfType = require('./types/instanceOf');
+const Model = require('./Model');
+const Slot = require('./Slot');
+const Collection = require('./Collection');
+const overloadedAccessor = require('./mixins/overloadedAccessor');
+const triggerParams = require('./mixins/triggerParams');
+const volumeParams = require('./mixins/volumeParams');
+const connectable = require('./mixins/connectable');
+const bypassable = require('./mixins/bypassable');
+const instanceOfType = require('./types/instanceOf');
 
-var ids = 'QWERTYUIOPASDFGHJKLZXCVBNM'.split('');
-var slotsProps = {};
-ids.forEach(function (id) {
+const ids = 'QWERTYUIOPASDFGHJKLZXCVBNM'.split('');
+const slotsProps = {};
+ids.forEach(id => {
   slotsProps[id] = 'slot';
 });
-var SlotsModel = Model.extend({
+const SlotsModel = Model.extend({
   props: slotsProps,
   dataTypes: {
     slot: instanceOfType('slot', Slot)
@@ -21,7 +21,7 @@ var SlotsModel = Model.extend({
   extraProperties: 'allow'
 });
 
-var Kit = Model.extend(triggerParams, volumeParams, connectable, bypassable, {
+const Kit = Model.extend(triggerParams, volumeParams, connectable, bypassable, {
 
   type: 'kit',
 
@@ -31,7 +31,7 @@ var Kit = Model.extend(triggerParams, volumeParams, connectable, bypassable, {
 
   slot: function (id, slot) {
     if (!id || typeof id !== 'string') {
-      throw new Error('Invalid slot identifier: ' + id);
+      throw new Error(`Invalid slot identifier: ${id}`);
     }
     else if (!slot) {
       slot = this.slots[id];

--- a/lib/Layer.js
+++ b/lib/Layer.js
@@ -1,14 +1,14 @@
-var Model = require('./Model');
-var triggerParams = require('./mixins/triggerParams');
-var volumeParams = require('./mixins/volumeParams');
-var connectable = require('./mixins/connectable');
-var bypassable = require('./mixins/bypassable');
-var Params = require('./Params');
+const Model = require('./Model');
+const triggerParams = require('./mixins/triggerParams');
+const volumeParams = require('./mixins/volumeParams');
+const connectable = require('./mixins/connectable');
+const bypassable = require('./mixins/bypassable');
+const Params = require('./Params');
 
-var context = null;
+let context = null;
 
 function createPool (factoryName) {
-  var nodes = [];
+  const nodes = [];
   return function pool(node) {
     if (node) {
       nodes.push(node);
@@ -22,17 +22,17 @@ function createPool (factoryName) {
   };
 }
 
-var gainPool = createPool('createGain');
-var pannerPool = createPool('createPanner');
+const gainPool = createPool('createGain');
+const pannerPool = createPool('createPanner');
 
-var destination = null;
+let destination = null;
 
-var Layer = Model.extend(triggerParams, volumeParams, {
+const Layer = Model.extend(triggerParams, volumeParams, {
 
   type: 'layer',
 
   props: {
-    sources: ['object', true, function () { return {}; }]
+    sources: ['object', true, () => ({})]
   },
 
   start: function (time, note, channel, pattern, kit, slot) {
@@ -48,32 +48,32 @@ var Layer = Model.extend(triggerParams, volumeParams, {
 
     context = context || this.context;
 
-    var params = this._params(note, channel, pattern, kit, slot);
-    var source = this._source(params);
+    const params = this._params(note, channel, pattern, kit, slot);
+    let source = this._source(params);
 
     if (source) {
-      var connections = this._getConnections(note, channel, pattern);
-      var destination = this._connectDestination(connections, params);
-      var gain = source._gain = gainPool();
+      const connections = this._getConnections(note, channel, pattern);
+      const destination = this._connectDestination(connections, params);
+      let gain = source._gain = gainPool();
       this._configureAttack(time, params, gain, destination);
-      var panner = this._configurePan(params, gain);
+      let panner = this._configurePan(params, gain);
       source.connect(panner || gain);
 
       this._startSource(time, params, source);
 
       this._triggerPlaybackStateEvent('started', time, params, note, channel, pattern, kit, slot);
 
-      var cid = note.cid || 'null';
+      const cid = note.cid || 'null';
       this.sources[cid] = this.sources[cid] || [];
       this.sources[cid].push(source);
 
       if (params.length) {
-        var stopTime = this._getStopTime(time, params, source);
+        const stopTime = this._getStopTime(time, params, source);
         this.stop(stopTime, note, channel, pattern);
       }
 
-      source.onended = function () {
-        var index = this.sources[cid].indexOf(source);
+      source.onended = () => {
+        const index = this.sources[cid].indexOf(source);
         this.sources[cid].splice(index, 1);
 
         gain.disconnect();
@@ -89,20 +89,20 @@ var Layer = Model.extend(triggerParams, volumeParams, {
         source = source.onended = source._gain = gain = panner = null;
 
         if (typeof note.after === 'function') note.after();
-      }.bind(this);
+      };
     }
   },
 
-  _getStopTime: function (time, params, source) {
-    return time + params.length;
+  _getStopTime: function(time, {length}, source) {
+    return time + length;
   },
 
   _triggerPlaybackStateEvent: function(event, time, params, note, channel, pattern, kit, slot) {
-    var self = this;
-    var lookahead = Math.floor((time - context.currentTime) * 1000) - 1;
+    const self = this;
+    let lookahead = Math.floor((time - context.currentTime) * 1000) - 1;
     if (lookahead < 0) lookahead = 0;
-    setTimeout(function () {
-      [note, channel, pattern, kit, slot, self].forEach(function (target) {
+    setTimeout(() => {
+      [note, channel, pattern, kit, slot, self].forEach(target => {
         target && target.trigger(event, note, params);
       });
     }, lookahead);
@@ -117,29 +117,29 @@ var Layer = Model.extend(triggerParams, volumeParams, {
     }
     note = note || {};
 
-    var params = this._params(note, channel, pattern, kit, slot);
-    var cid = note.cid || 'null';
-    var sources = this.sources[cid] || [];
+    const params = this._params(note, channel, pattern, kit, slot);
+    const cid = note.cid || 'null';
+    let sources = this.sources[cid] || [];
 
     if (cid === 'null') {
       sources = [];
-      Object.keys(this.sources).forEach(function (cid) {
+      Object.keys(this.sources).forEach(cid => {
         sources = sources.concat(this.sources[cid]);
-      }.bind(this));
+      });
     }
 
-    sources.forEach(function (source) {
+    sources.forEach(source => {
       if (source._gain) {
         this._configureRelease(time, params, source._gain);
       }
       this._stopSource(time, params, source);
-    }.bind(this));
+    });
   },
 
   _paramsSources: function (note, channel, pattern, kit, slot) {
     slot = slot || this.collection && this.collection.parent || {};
     kit = kit || slot && slot.kit || {};
-    var patternParams = {
+    const patternParams = {
       volume: pattern && pattern.volume,
       pitch: pattern && pattern.pitch,
       pan: pattern && pattern.pan
@@ -148,14 +148,14 @@ var Layer = Model.extend(triggerParams, volumeParams, {
   },
 
   _params: function (note, channel, pattern, kit, slot) {
-    var sources = this._paramsSources(note, channel, pattern, kit, slot);
+    const sources = this._paramsSources(note, channel, pattern, kit, slot);
     return Params.fromSources(sources);
   },
 
   _getConnections: function (note, channel, pattern) {
-    var sources = this._paramsSources(note, channel, pattern);
-    var connections = [];
-    sources.forEach(function (source) {
+    const sources = this._paramsSources(note, channel, pattern);
+    let connections = [];
+    sources.forEach(source => {
       if (source && source.connections) {
         connections = connections.concat(source.connections);
       }
@@ -176,7 +176,7 @@ var Layer = Model.extend(triggerParams, volumeParams, {
   },
 
   _source: function (params) {
-    throw new Error('Required method "_source" is not implemented for ' + this.cid);
+    throw new Error(`Required method "_source" is not implemented for ${this.cid}`);
   },
 
   _getLocalDestination: function () {
@@ -189,20 +189,20 @@ var Layer = Model.extend(triggerParams, volumeParams, {
     return destination;
   },
 
-  _connectDestination: function (connections, params) {
+  _connectDestination: function(connections, {bypass}) {
 
-    var localDestination = this._getLocalDestination();
-    if (params.bypass === true) return localDestination;
-    var cid = this.cid;
+    let localDestination = this._getLocalDestination();
+    if (bypass === true) return localDestination;
+    const cid = this.cid;
 
-    connections.filter(function (connection) {
-      if (params.bypass === connection.type || Array.isArray(params.bypass) && ~params.bypass.indexOf(connection.type)) return false;
-      return !connection.bypass;
-    }).reverse().forEach(function (connection, index, list) {
-      var next = list[index - 1];
-      var node = connection.getNode(next && next.cid || 'destination');
+    connections.filter(({type, bypass}) => {
+      if (bypass === type || Array.isArray(bypass) && ~bypass.indexOf(type)) return false;
+      return !bypass;
+    }).reverse().forEach((connection, index, list) => {
+      const next = list[index - 1];
+      const node = connection.getNode(next && next.cid || 'destination');
       if (node.__connectedTo && node.__connectedTo !== localDestination) {
-        console.error('Attempted to reconnect already connected effect (' + connection.cid + ') for target ' + cid);
+        console.error(`Attempted to reconnect already connected effect (${connection.cid}) for target ${cid}`);
       }
       else if (!node._connectedTo) {
         node.connect(localDestination);
@@ -214,11 +214,11 @@ var Layer = Model.extend(triggerParams, volumeParams, {
     return localDestination;
   },
 
-  _configurePan: function (params, out) {
-    if (params.pan !== 0) {
-      var panner = pannerPool();
-      var x = params.pan / 100;
-      var z = 1 - Math.abs(x);
+  _configurePan: function({pan}, out) {
+    if (pan !== 0) {
+      const panner = pannerPool();
+      const x = pan / 100;
+      const z = 1 - Math.abs(x);
       panner.setPosition(x, 0, z);
       panner.connect(out);
       return panner;
@@ -226,7 +226,7 @@ var Layer = Model.extend(triggerParams, volumeParams, {
   },
 
   _configureAttack: function (time, params, gain, destination) {
-    var volume = (params.volume !== null && params.volume !== undefined ? params.volume : 100) / 100;
+    const volume = (params.volume !== null && params.volume !== undefined ? params.volume : 100) / 100;
     gain.connect(destination);
     gain.gain.value = 0;
     gain.gain.setValueAtTime(0, time);
@@ -234,7 +234,7 @@ var Layer = Model.extend(triggerParams, volumeParams, {
   },
 
   _configureRelease: function (time, params, gain) {
-    var volume = (params.volume !== null && params.volume !== undefined ? params.volume : 100) / 100;
+    const volume = (params.volume !== null && params.volume !== undefined ? params.volume : 100) / 100;
     if (params.release) {
       gain.gain.cancelScheduledValues(time - 0.001);
       gain.gain.linearRampToValueAtTime(volume, time - params.release);

--- a/lib/LoadingState.js
+++ b/lib/LoadingState.js
@@ -1,11 +1,11 @@
-var Model = require('./Model');
+const Model = require('./Model');
 
-var LoadingState = Model.extend({
+const LoadingState = Model.extend({
 
   type: 'loadingState',
 
   props: {
-    sources: ['array', true, function () { return []; }]
+    sources: ['array', true, () => []]
   },
 
   derived: {
@@ -25,14 +25,14 @@ var LoadingState = Model.extend({
   },
 
   _addSource: function (src) {
-    if (this.sources.indexOf(src) < 0) {
+    if (!this.sources.includes(src)) {
       this.sources.push(src);
       this.trigger('change:sources');
     }
   },
 
   _removeSource: function (src) {
-    var index = this.sources.indexOf(src);
+    const index = this.sources.indexOf(src);
     if (index > -1) {
       this.sources.splice(index, 1);
       this.trigger('change:sources');

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -1,20 +1,20 @@
-var context = require('./utils/context');
-var vent = require('./utils/vent');
-var State = require('ampersand-state');
-var uniqueId = require('./utils/uniqueId');
-var merge = require('lodash.merge');
-var memoize = require('meemo');
-var changeRE = /^change:/;
+const context = require('./utils/context');
+const vent = require('./utils/vent');
+const State = require('ampersand-state');
+const uniqueId = require('./utils/uniqueId');
+const merge = require('lodash.merge');
+const memoize = require('meemo');
+const changeRE = /^change:/;
 
 function hashArgs () {
-  var args = new Array(arguments.length);
-  for (var i = 0, l = arguments.length; i < l; i++) {
+  const args = new Array(arguments.length);
+  for (let i = 0, l = arguments.length; i < l; i++) {
     args[i] = arguments[i];
   }
   return args.join('//');
 }
 
-var Model = State.extend({
+const Model = State.extend({
 
   type: 'model',
 
@@ -43,11 +43,11 @@ var Model = State.extend({
   },
 
   cacheMethodUntilEvent: function (name, event) {
-    var originalMethod = this[name].bind(this);
-    var reset = function () {
+    const originalMethod = this[name].bind(this);
+    const reset = () => {
       this[name] = memoize(originalMethod, hashArgs);
       return reset;
-    }.bind(this);
+    };
     this.on(event, reset);
     return reset();
   },
@@ -59,35 +59,35 @@ var Model = State.extend({
 
   _initCollections: function () {
     State.prototype._initCollections.call(this);
-    for (var coll in this._collections) {
+    for (const coll in this._collections) {
       this.listenTo(this[coll], 'all', this._getCollectionEventBubblingHandler(coll));
     }
   },
 
   _getCollectionEventBubblingHandler: function (propertyName) {
-    return function (eventName, model, newValue, collection) {
-      var validNames = ['change', 'add', 'remove'];
+    return (eventName, model, newValue, collection) => {
+      const validNames = ['change', 'add', 'remove'];
       if (~validNames.indexOf(eventName)) {
-        this.trigger('change:' + propertyName, model, newValue);
+        this.trigger(`change:${propertyName}`, model, newValue);
         this.trigger(eventName, this);
       }
       else {
-        var next;
+        let next;
         while (validNames.length) {
           next = validNames.shift();
-          if (~eventName.indexOf(next + ':')) {
-            var parts = eventName.split(':');
-            var type = parts[0];
-            var callers = [propertyName].concat(parts[1].split('.'));
+          if (~eventName.indexOf(`${next}:`)) {
+            const parts = eventName.split(':');
+            const type = parts[0];
+            const callers = [propertyName].concat(parts[1].split('.'));
             while (callers.length) {
-              this.trigger(type + ':' + callers.join('.'), model, newValue);
+              this.trigger(`${type}:${callers.join('.')}`, model, newValue);
               callers.pop();
             }
             this.trigger(type, model, newValue);
           }
         }
       }
-    }.bind(this);
+    };
   }
 });
 

--- a/lib/Note.js
+++ b/lib/Note.js
@@ -1,21 +1,21 @@
-var PositionModel = require('./PositionModel');
-var rawKeys = ['position', 'target', 'duration', 'volume', 'pitch', 'pan'];
-var numberInRangeType = require('./types/numberInRange');
-var regexpType = require('./types/regexp');
-var triggerParams = require('./mixins/triggerParams');
-var volumeParams = require('./mixins/volumeParams');
-var oscillatorParams = require('./mixins/oscillatorParams');
-var sampleParams = require('./mixins/sampleParams');
-var connectable = require('./mixins/connectable');
-var bypassable = require('./mixins/bypassable');
+const PositionModel = require('./PositionModel');
+const rawKeys = ['position', 'target', 'duration', 'volume', 'pitch', 'pan'];
+const numberInRangeType = require('./types/numberInRange');
+const regexpType = require('./types/regexp');
+const triggerParams = require('./mixins/triggerParams');
+const volumeParams = require('./mixins/volumeParams');
+const oscillatorParams = require('./mixins/oscillatorParams');
+const sampleParams = require('./mixins/sampleParams');
+const connectable = require('./mixins/connectable');
+const bypassable = require('./mixins/bypassable');
 
-var Note = PositionModel.extend(triggerParams, volumeParams, oscillatorParams, sampleParams, connectable, bypassable, {
+const Note = PositionModel.extend(triggerParams, volumeParams, oscillatorParams, sampleParams, connectable, bypassable, {
 
   type: 'note',
 
   props: {
     target: ['target', false],
-    ghosts: ['array', true, function () { return []; }],
+    ghosts: ['array', true, () => []],
     transform: 'function',
     after: 'function',
     data: 'object'
@@ -60,19 +60,17 @@ var Note = PositionModel.extend(triggerParams, volumeParams, oscillatorParams, s
   }
 });
 
-var plainPositionRE = /^\d+\.\d+\.\d+$/;
-Note.isPlainPosition = function (position) {
-  return plainPositionRE.test(position);
-};
+const plainPositionRE = /^\d+\.\d+\.\d+$/;
+Note.isPlainPosition = position => plainPositionRE.test(position);
 
-Note.fromRaw = function (raw) {
-  var attributes = {};
-  var last = raw[raw.length - 1];
+Note.fromRaw = raw => {
+  let attributes = {};
+  const last = raw[raw.length - 1];
   if (typeof last === 'object' && last !== null) {
     attributes = raw.pop();
   }
-  raw.forEach(function (value, index) {
-    var key = rawKeys[index];
+  raw.forEach((value, index) => {
+    const key = rawKeys[index];
     if (key && value) {
       attributes[key] = value;
     }

--- a/lib/Oscillator.js
+++ b/lib/Oscillator.js
@@ -1,15 +1,15 @@
-var Layer = require('./Layer');
-var audioNotes = require('audio-notes');
-var oscillatorParams = require('./mixins/oscillatorParams');
+const Layer = require('./Layer');
+const audioNotes = require('audio-notes');
+const oscillatorParams = require('./mixins/oscillatorParams');
 
-var Oscillator = Layer.extend(oscillatorParams, {
+const Oscillator = Layer.extend(oscillatorParams, {
 
   type: 'oscillator',
 
   _source: function (params) {
-    var oscillator = this.context.createOscillator();
+    const oscillator = this.context.createOscillator();
 
-    var frequency = params.frequency;
+    let frequency = params.frequency;
     if (params.note) {
       frequency = audioNotes[params.note] || frequency;
     }

--- a/lib/Params.js
+++ b/lib/Params.js
@@ -1,17 +1,17 @@
 require('es6-object-assign').polyfill();
 
-var Model = require('./Model');
-var triggerParams = require('./mixins/triggerParams');
-var volumeParams = require('./mixins/volumeParams');
-var oscillatorParams = require('./mixins/oscillatorParams');
-var sampleParams = require('./mixins/sampleParams');
-var numberInRangeType = require('./types/numberInRange');
-var bypassable = require('./mixins/bypassable');
-var memoize = require('meemo');
+const Model = require('./Model');
+const triggerParams = require('./mixins/triggerParams');
+const volumeParams = require('./mixins/volumeParams');
+const oscillatorParams = require('./mixins/oscillatorParams');
+const sampleParams = require('./mixins/sampleParams');
+const numberInRangeType = require('./types/numberInRange');
+const bypassable = require('./mixins/bypassable');
+const memoize = require('meemo');
 
-var prime = null;
+let prime = null;
 
-var Params = Model.extend(triggerParams, volumeParams, oscillatorParams, sampleParams, bypassable, {
+const Params = Model.extend(triggerParams, volumeParams, oscillatorParams, sampleParams, bypassable, {
   type: 'params',
 
   props: {
@@ -23,23 +23,23 @@ var Params = Model.extend(triggerParams, volumeParams, oscillatorParams, sampleP
   }
 });
 
-Params.mergeSources = memoize(function (params, sources) {
-  var multipliers = ['volume'];
-  var adders = ['pitch', 'pan'];
-  var keys = Object.keys(Params.prototype._definition);
+Params.mergeSources = memoize((params, sources) => {
+  const multipliers = ['volume'];
+  const adders = ['pitch', 'pan'];
+  const keys = Object.keys(Params.prototype._definition);
 
-  keys.forEach(function (key) {
+  keys.forEach(key => {
     if (key === 'id') { return; }
-    sources.forEach(function (source) {
+    sources.forEach(source => {
       if (!source) { return; }
-      var value = source[key];
+      let value = source[key];
       if (~multipliers.indexOf(key)) {
         if (value < 0) { return; }
         if (value === 0) {
           params[key] = 0;
           return;
         }
-        var multiplier = value / 100;
+        const multiplier = value / 100;
         params[key] = params[key] !== undefined ? params[key] * multiplier : value;
       }
       else if (~adders.indexOf(key)) {
@@ -60,19 +60,19 @@ Params.mergeSources = memoize(function (params, sources) {
   });
 
   return params;
-}, function (params, sources) {
-  var hash = '';
-  var keys = Object.keys(Params.prototype._definition);
-  var length = keys.length - 1;
-  var source, value;
+}, (params, sources) => {
+  let hash = '';
+  const keys = Object.keys(Params.prototype._definition);
+  const length = keys.length - 1;
+  let source, value;
 
-  for (var i = 0, max = sources.length; i < max; i++) {
+  for (let i = 0, max = sources.length; i < max; i++) {
     source = sources[i];
     if (source) {
-      for (var j = 0, maxJ = keys.length; j < maxJ; j++) {
+      for (let j = 0, maxJ = keys.length; j < maxJ; j++) {
         value = source[keys[j]];
         if (value && keys[j] !== 'id') {
-          hash += keys[j] + ':' + value + '/';
+          hash += `${keys[j]}:${value}/`;
         }
       }
     }
@@ -85,9 +85,9 @@ Params.mergeSources = memoize(function (params, sources) {
   return hash;
 });
 
-Params.calculateLength = function (params) {
-  var existingLength = params.length || 0;
-  var lengthFromDuration = params.duration && Params.lengthFromDuration(params, params.duration) || 0;
+Params.calculateLength = params => {
+  const existingLength = params.length || 0;
+  const lengthFromDuration = params.duration && Params.lengthFromDuration(params, params.duration) || 0;
   if (lengthFromDuration && lengthFromDuration < existingLength || !existingLength) {
     params.hasLengthFromDuration = true;
     return lengthFromDuration;
@@ -97,23 +97,23 @@ Params.calculateLength = function (params) {
   }
 };
 
-Params.lengthFromDuration = function (params, duration) {
-  var secondsPerBeat = 60 / params.tempo;
-  var secondsPerTick = secondsPerBeat / 96;
+Params.lengthFromDuration = ({tempo}, duration) => {
+  const secondsPerBeat = 60 / tempo;
+  const secondsPerTick = secondsPerBeat / 96;
   return duration * secondsPerTick;
 };
 
-Params.correctAttackAndRelease = function (params) {
-  var total = params.attack + params.release;
+Params.correctAttackAndRelease = params => {
+  const total = params.attack + params.release;
   if (params.length && total > params.length) {
     params.attack = (params.length / total) * params.attack;
     params.release = (params.length / total) * params.release;
   }
 };
 
-Params.fromSources = function (sources) {
+Params.fromSources = sources => {
   prime = prime || new Params();
-  var params = prime.toJSON();
+  let params = prime.toJSON();
   params = Object.assign({}, Params.mergeSources(params, sources.reverse()));
   prime.vent.trigger('clock:tempo', params);
   params.length = Params.calculateLength(params);

--- a/lib/Pattern.js
+++ b/lib/Pattern.js
@@ -1,14 +1,14 @@
-var PlayableModel = require('./PlayableModel');
-var Channel = require('./Channel');
-var Collection = require('./Collection');
-var overloadedAccessor = require('./mixins/overloadedAccessor');
-var volumeParams = require('./mixins/volumeParams');
-var Kit = require('./Kit');
-var numberInRangeType = require('./types/numberInRange');
-var Sequence = require('./Sequence');
-var sequenceActions = require('./utils/sequenceActions');
+const PlayableModel = require('./PlayableModel');
+const Channel = require('./Channel');
+const Collection = require('./Collection');
+const overloadedAccessor = require('./mixins/overloadedAccessor');
+const volumeParams = require('./mixins/volumeParams');
+const Kit = require('./Kit');
+const numberInRangeType = require('./types/numberInRange');
+const Sequence = require('./Sequence');
+const sequenceActions = require('./utils/sequenceActions');
 
-var Pattern = PlayableModel.extend(volumeParams, {
+const Pattern = PlayableModel.extend(volumeParams, {
 
   type: 'pattern',
 
@@ -44,25 +44,25 @@ var Pattern = PlayableModel.extend(volumeParams, {
   },
 
   notes: function (bar, beat, tick) {
-    var notes = [];
-    this.channels.forEach(function (channel) {
+    const notes = [];
+    this.channels.forEach(channel => {
       notes.push.apply(notes, channel.notes(bar, beat, tick));
     });
     return notes;
   },
 
   then: function () {
-    var sequences = sequenceActions.then(this, arguments);
+    const sequences = sequenceActions.then(this, arguments);
     return new Sequence({ sequences: sequences });
   },
 
   after: function () {
-    var sequences = sequenceActions.after(this, arguments);
+    const sequences = sequenceActions.after(this, arguments);
     return new Sequence({ sequences: sequences });
   },
 
   and: function () {
-    var sequences = sequenceActions.and(this, arguments);
+    const sequences = sequenceActions.and(this, arguments);
     return new Sequence({ sequences: sequences });
   },
 
@@ -75,15 +75,15 @@ var Pattern = PlayableModel.extend(volumeParams, {
   },
 
   _runEvent: function (event, time, note, channel) {
-    var kitId = parseInt(note.target.slice(0, 1), 10);
-    var slotId = note.target.slice(1);
-    var kit = this.kit(kitId);
+    const kitId = parseInt(note.target.slice(0, 1), 10);
+    const slotId = note.target.slice(1);
+    const kit = this.kit(kitId);
     if (kit) {
       if (kit.mute) return;
       kit.slot(slotId)[event](time, note, channel, this, kit);
     }
     else {
-      console.warn('No kit found for ' + note.target, note);
+      console.warn(`No kit found for ${note.target}`, note);
     }
   }
 

--- a/lib/PlayableModel.js
+++ b/lib/PlayableModel.js
@@ -1,5 +1,5 @@
-var Model = require('./Model');
-var PlayableModel = Model.extend({
+const Model = require('./Model');
+const PlayableModel = Model.extend({
 
   type: 'playable-model',
 
@@ -31,7 +31,7 @@ var PlayableModel = Model.extend({
   },
 
   detachGhosts: function () {
-    this.notes(true).forEach(function (note) {
+    this.notes(true).forEach(note => {
       note.detachGhosts();
     });
   },
@@ -41,7 +41,7 @@ var PlayableModel = Model.extend({
   },
 
   _onChangePlaying: function () {
-    var method = this.playing ? 'start' : 'pause';
+    const method = this.playing ? 'start' : 'pause';
     this[method]();
   }
 });

--- a/lib/PositionModel.js
+++ b/lib/PositionModel.js
@@ -1,10 +1,10 @@
-var Model = require('./Model');
-var numberInRangeType = require('./types/numberInRange');
-var regexpType = require('./types/regexp');
-var padLeft = require('lodash.padleft');
-var memoize = require('meemo');
+const Model = require('./Model');
+const numberInRangeType = require('./types/numberInRange');
+const regexpType = require('./types/regexp');
+const padLeft = require('lodash.padleft');
+const memoize = require('meemo');
 
-var PositionModel = Model.extend({
+const PositionModel = Model.extend({
 
   type: 'position-model',
 
@@ -46,18 +46,18 @@ var PositionModel = Model.extend({
   },
 
   _updatePositionFromFragments: function () {
-    var fragments = this.fragments();
-    var bar = this.bar || fragments[0];
-    var beat = this.beat || fragments[1];
-    var tick = this.tick || fragments[2];
-    tick = tick < 10 && tick !== '00' ? '0' + tick : tick;
+    const fragments = this.fragments();
+    const bar = this.bar || fragments[0];
+    const beat = this.beat || fragments[1];
+    let tick = this.tick || fragments[2];
+    tick = tick < 10 && tick !== '00' ? `0${tick}` : tick;
     this.position = [bar, beat, tick].join('.');
   }
 });
 
-PositionModel.paddedPosition = memoize(function (position) {
-  var length = 3;
-  var fragments = PositionModel.fragments(position);
+PositionModel.paddedPosition = memoize(position => {
+  const length = 3;
+  const fragments = PositionModel.fragments(position);
   return [
     padLeft(fragments[0], length, '0'),
     padLeft(fragments[1], length, '0'),
@@ -65,18 +65,16 @@ PositionModel.paddedPosition = memoize(function (position) {
   ].join('.');
 });
 
-PositionModel.fragments = memoize(function (position) {
-  return position.split('.').map(function (n) {
-    var num = parseInt(n, 10);
-    return /^\d+$/.test(n) && !isNaN(num) ? num : n;
-  });
-});
+PositionModel.fragments = memoize(position => position.split('.').map(n => {
+  const num = parseInt(n, 10);
+  return /^\d+$/.test(n) && !isNaN(num) ? num : n;
+}));
 
-var names = ['bar', 'beat', 'tick'];
-PositionModel.getFragmentsObject = memoize(function (position) {
-  var fragments = PositionModel.fragments(position);
-  var values = {};
-  fragments.forEach(function (fragment, index) {
+const names = ['bar', 'beat', 'tick'];
+PositionModel.getFragmentsObject = memoize(position => {
+  const fragments = PositionModel.fragments(position);
+  const values = {};
+  fragments.forEach((fragment, index) => {
     if (fragment && typeof fragment === 'number' && !isNaN(fragment) && fragment > 0) {
       values[names[index]] = fragment;
     }

--- a/lib/Sample.js
+++ b/lib/Sample.js
@@ -1,15 +1,15 @@
-var Layer = require('./Layer');
-var Kit = require('./Kit');
-var Params = require('./Params');
-var BufferHelper = require('./BufferHelper');
-var sampleParams = require('./mixins/sampleParams');
-var uniqueId = require('./utils/uniqueId');
-var slotIds = 'QWERTYUIOPASDFGHJKLZXCVBNM';
+const Layer = require('./Layer');
+const Kit = require('./Kit');
+const Params = require('./Params');
+const BufferHelper = require('./BufferHelper');
+const sampleParams = require('./mixins/sampleParams');
+const uniqueId = require('./utils/uniqueId');
+const slotIds = 'QWERTYUIOPASDFGHJKLZXCVBNM';
 
-var buffers = {};
-var loading = {};
+const buffers = {};
+const loading = {};
 
-var Sample = Layer.extend({
+const Sample = Layer.extend({
 
   type: 'sample',
 
@@ -45,7 +45,7 @@ var Sample = Layer.extend({
       return slotIds[index];
     }
     else {
-      var cycles = Math.floor(index / slotIds.length);
+      const cycles = Math.floor(index / slotIds.length);
       index -= (cycles * slotIds.length);
       return slotIds[cycles - 1] + slotIds[index];
     }
@@ -53,25 +53,25 @@ var Sample = Layer.extend({
 
   slice: function (pieces) {
     // not clean, but I'm not sure of another way of solving this circular dependency
-    var kit = new this.vent.bap.kit();
-    for (var i = 0; i < pieces; i++) {
+    const kit = new this.vent.bap.kit();
+    for (let i = 0; i < pieces; i++) {
       kit.slot(this._getSlotId(i)).layer(this.with({
-        sliceExpression: '' + (i + 1) + '/' + pieces
+        sliceExpression: `${i + 1}/${pieces}`
       }));
     }
     return kit;
   },
 
   _params: function () {
-    var params = Layer.prototype._params.apply(this, arguments);
+    const params = Layer.prototype._params.apply(this, arguments);
 
     params.length = params.length || this.buffer && (this.buffer.duration - params.offset) || 0;
 
-    var playbackRate = params.playbackRate = this._getPlaybackRate(params);
+    const playbackRate = params.playbackRate = this._getPlaybackRate(params);
 
     if (!params.hasLengthFromDuration) {
-      var adjustedLength = params.length / playbackRate;
-      var durationLength = params.duration && Params.lengthFromDuration(params, params.duration);
+      const adjustedLength = params.length / playbackRate;
+      const durationLength = params.duration && Params.lengthFromDuration(params, params.duration);
 
       if (durationLength && durationLength < adjustedLength) {
         params.hasLengthFromDuration = true;
@@ -90,7 +90,7 @@ var Sample = Layer.extend({
       throw new Error('Cannot start sample without loaded buffer');
     }
 
-    var source = this.context.createBufferSource();
+    const source = this.context.createBufferSource();
     source.buffer = BufferHelper.makeBuffer(params, this.buffer, this.context);
 
     source.playbackRate.value = params.playbackRate;
@@ -104,17 +104,17 @@ var Sample = Layer.extend({
     return source;
   },
 
-  _getStopTime: function (time, params, source) {
-    var duration = params.hasLengthFromDuration ? source.buffer.duration : source.buffer.duration / params.playbackRate;
+  _getStopTime: function(time, {hasLengthFromDuration, playbackRate}, {buffer}) {
+    const duration = hasLengthFromDuration ? buffer.duration : buffer.duration / playbackRate;
     return time + duration;
   },
 
-  _getPlaybackRate: function (params) {
-    return Math.pow(2, params.pitch / 12);
+  _getPlaybackRate: function({pitch}) {
+    return Math.pow(2, pitch / 12);
   },
 
   _loadSample: function (countLoading) {
-    var buffer = buffers[this.src];
+    const buffer = buffers[this.src];
     if (!buffer) {
       this.loaded = false;
 
@@ -128,11 +128,11 @@ var Sample = Layer.extend({
       this.vent.trigger('loadingState:add', this.src);
       loading[this.src] = 1;
 
-      var request = new XMLHttpRequest();
+      const request = new XMLHttpRequest();
       request.open('GET', this.src, true);
       request.responseType = 'arraybuffer';
       request.onload = function soundWasLoaded () {
-        this.context.decodeAudioData(request.response, function (buffer) {
+        this.context.decodeAudioData(request.response, buffer => {
           buffer.uid = uniqueId('buffer');
           this.buffer = buffers[this.src] = buffer;
           loading[this.src]--;
@@ -141,7 +141,7 @@ var Sample = Layer.extend({
             this.vent.trigger('loadingState:remove', this.src);
           }
           request.onload = null;
-        }.bind(this));
+        });
       }.bind(this);
       request.send();
     }
@@ -164,12 +164,12 @@ var Sample = Layer.extend({
 
   _configureSlice: function () {
     if (this.buffer && this.loaded && this.sliceExpression) {
-      var length = this.buffer.duration;
-      var parts = this.sliceExpression.split('/');
-      var index = parseInt(parts[0], 10) - 1;
-      var total = parseInt(parts[1], 10);
-      var sliceLength = length / total;
-      var offset = index * sliceLength;
+      const length = this.buffer.duration;
+      const parts = this.sliceExpression.split('/');
+      const index = parseInt(parts[0], 10) - 1;
+      const total = parseInt(parts[1], 10);
+      const sliceLength = length / total;
+      const offset = index * sliceLength;
 
       this.length = sliceLength;
       this.offset = offset;

--- a/lib/Sequence.js
+++ b/lib/Sequence.js
@@ -1,13 +1,9 @@
-var PlayableModel = require('./PlayableModel');
-var PositionModel = require('./PositionModel');
-var sequenceActions = require('./utils/sequenceActions');
+const PlayableModel = require('./PlayableModel');
+const PositionModel = require('./PositionModel');
+const sequenceActions = require('./utils/sequenceActions');
 
 function hashify (grid) {
-  return grid.map(function (row) {
-    return row.map(function (item) {
-      return item.cid;
-    }).join('+');
-  }).join('>');
+  return grid.map(row => row.map(({cid}) => cid).join('+')).join('>');
 }
 
 function findFirst (grid) {
@@ -15,17 +11,17 @@ function findFirst (grid) {
 }
 
 function findLongest (row) {
-  var longest = 0;
-  row.forEach(function (item) {
-    if (item.bars > longest) {
-      longest = item.bars;
+  let longest = 0;
+  row.forEach(({bars}) => {
+    if (bars > longest) {
+      longest = bars;
     }
   });
   return longest;
 }
 
 function forAll (grid, cb) {
-  grid.forEach(function (row) {
+  grid.forEach(row => {
     if (Array.isArray(row)) {
       forAll(row, cb);
     }
@@ -35,13 +31,13 @@ function forAll (grid, cb) {
   });
 }
 
-var Sequence = PlayableModel.extend({
+const Sequence = PlayableModel.extend({
 
   type: 'sequence',
 
   props: {
     loop: ['boolean', true, false],
-    sequences: ['sequence-grid', true, function () { return []; }]
+    sequences: ['sequence-grid', true, () => []]
   },
 
   dataTypes: {
@@ -54,15 +50,15 @@ var Sequence = PlayableModel.extend({
       },
 
       compare: function (currentVal, newVal) {
-        var isSame = hashify(currentVal) === hashify(newVal);
+        const isSame = hashify(currentVal) === hashify(newVal);
         if (!isSame) {
-          forAll(currentVal, function (seq) {
+          forAll(currentVal, seq => {
             this.stopListening(seq);
-          }.bind(this));
+          });
 
-          forAll(newVal, function (seq) {
+          forAll(newVal, seq => {
             this.listenTo(seq, 'change:channels change:sequences', this._forwardChannelChange);
-          }.bind(this));
+          });
         }
         return isSame;
       }
@@ -73,16 +69,16 @@ var Sequence = PlayableModel.extend({
     tempo: {
       deps: ['sequences'],
       fn: function () {
-        var first = findFirst(this.sequences);
+        const first = findFirst(this.sequences);
         return first && first.tempo || 120;
       }
     },
     bars: {
       deps: ['sequences'],
       fn: function () {
-        var total = 0;
+        let total = 0;
         if (this.sequences.length) {
-          this.sequences.forEach(function (row) {
+          this.sequences.forEach(row => {
             total += findLongest(row);
           });
         }
@@ -92,18 +88,18 @@ var Sequence = PlayableModel.extend({
     beatsPerBar: {
       deps: ['sequences'],
       fn: function () {
-        var first = findFirst(this.sequences);
+        const first = findFirst(this.sequences);
         return first && first.beatsPerBar || 4;
       }
     }
   },
 
   constructor: function () {
-    var args = Array.prototype.slice.call(arguments);
-    var types = ['sequence', 'pattern'];
-    var sequences = [];
-    var cont = true;
-    var next;
+    const args = Array.prototype.slice.call(arguments);
+    const types = ['sequence', 'pattern'];
+    const sequences = [];
+    let cont = true;
+    let next;
 
     while (cont && args.length) {
       if (args[0] && ~types.indexOf(args[0].type)) {
@@ -132,17 +128,17 @@ var Sequence = PlayableModel.extend({
   },
 
   notes: function (bar, beat, tick) {
-    var notes = {};
+    const notes = {};
     if (bar < 1 || bar > this.bars) throw new Error('Invalid argument: bar is not within sequence length');
 
     notes[bar] = [];
-    var patternsForBar = this.patterns(bar);
+    const patternsForBar = this.patterns(bar);
 
-    var cid = this.cid;
-    Object.keys(patternsForBar).forEach(function (offset) {
-      var patterns = patternsForBar[offset];
-      var innerBar = bar - parseInt(offset, 10);
-      patterns.forEach(function (pattern) {
+    const cid = this.cid;
+    Object.keys(patternsForBar).forEach(offset => {
+      const patterns = patternsForBar[offset];
+      const innerBar = bar - parseInt(offset, 10);
+      patterns.forEach(pattern => {
         notes[bar] = notes[bar].concat(pattern.notes(innerBar, beat, tick));
       });
     });
@@ -153,11 +149,11 @@ var Sequence = PlayableModel.extend({
   patterns: function (bar, outerOffset) {
     if (typeof bar !== 'number') throw new Error('Invalid argument: bar is not a number');
     if (bar < 1 || bar > this.bars) throw new Error('Invalid argument: bar is not within sequence length');
-    var patterns = {};
-    var sequences = this.sequences.slice();
-    var offset = 0;
+    const patterns = {};
+    let sequences = this.sequences.slice();
+    let offset = 0;
     outerOffset = outerOffset || 0;
-    var next, longest, start, end;
+    let next, longest, start, end;
 
     while (sequences.length) {
       next = sequences.shift();
@@ -172,13 +168,13 @@ var Sequence = PlayableModel.extend({
       }
     }
 
-    var cid = this.cid;
-    next.forEach(function (seq) {
-      var innerOffset = offset + outerOffset;
+    const cid = this.cid;
+    next.forEach(seq => {
+      const innerOffset = offset + outerOffset;
       if (seq.type === 'sequence') {
-        var nestedPatternList = seq.patterns(bar - offset, innerOffset);
-        Object.keys(nestedPatternList).forEach(function (nestedOffset) {
-          var nestedPatterns = nestedPatternList[nestedOffset];
+        const nestedPatternList = seq.patterns(bar - offset, innerOffset);
+        Object.keys(nestedPatternList).forEach(nestedOffset => {
+          const nestedPatterns = nestedPatternList[nestedOffset];
           patterns[nestedOffset] = (patterns[nestedOffset] || []).concat(nestedPatterns);
         });
       }
@@ -192,19 +188,17 @@ var Sequence = PlayableModel.extend({
   },
 
   tempoAt: function (bar) {
-    var tempoChanges = this.tempoChanges();
-    var validChanges = tempoChanges.filter(function (change) {
-      return change[0] <= bar;
-    });
+    const tempoChanges = this.tempoChanges();
+    const validChanges = tempoChanges.filter(change => change[0] <= bar);
     return validChanges.length ? validChanges[validChanges.length - 1][1] : 120;
   },
 
   tempoChanges: function () {
-    var changes = [];
-    var bar = 1;
-    var lastTempo = null;
+    const changes = [];
+    let bar = 1;
+    let lastTempo = null;
 
-    this.sequences.forEach(function (row) {
+    this.sequences.forEach(row => {
       row = row[0];
       if (row.tempo !== lastTempo) {
         changes.push([bar, row.tempo, row.beatsPerBar]);
@@ -217,17 +211,17 @@ var Sequence = PlayableModel.extend({
   },
 
   then: function () {
-    var sequences = sequenceActions.then(this, arguments);
+    const sequences = sequenceActions.then(this, arguments);
     return new this.constructor({ sequences: sequences });
   },
 
   after: function () {
-    var sequences = sequenceActions.after(this, arguments);
+    const sequences = sequenceActions.after(this, arguments);
     return new this.constructor({ sequences: sequences });
   },
 
   and: function () {
-    var sequences = sequenceActions.and(this, arguments);
+    const sequences = sequenceActions.and(this, arguments);
     return new this.constructor({ sequences: sequences });
   },
 

--- a/lib/Slot.js
+++ b/lib/Slot.js
@@ -1,14 +1,14 @@
-var Model = require('./Model');
-var Layer = require('./Layer');
-var Collection = require('./Collection');
-var overloadedAccessor = require('./mixins/overloadedAccessor');
-var triggerParams = require('./mixins/triggerParams');
-var volumeParams = require('./mixins/volumeParams');
-var connectable = require('./mixins/connectable');
-var bypassable = require('./mixins/bypassable');
-var sampleShortcut = require('./mixins/sampleShortcut');
+const Model = require('./Model');
+const Layer = require('./Layer');
+const Collection = require('./Collection');
+const overloadedAccessor = require('./mixins/overloadedAccessor');
+const triggerParams = require('./mixins/triggerParams');
+const volumeParams = require('./mixins/volumeParams');
+const connectable = require('./mixins/connectable');
+const bypassable = require('./mixins/bypassable');
+const sampleShortcut = require('./mixins/sampleShortcut');
 
-var Slot = Model.extend(triggerParams, volumeParams, bypassable, {
+const Slot = Model.extend(triggerParams, volumeParams, bypassable, {
 
   type: 'slot',
 
@@ -25,16 +25,16 @@ var Slot = Model.extend(triggerParams, volumeParams, bypassable, {
 
   start: function (time, note, channel, pattern, kit) {
     if (!this.mute) {
-      this.layers.each(function (layer) {
+      this.layers.each(layer => {
         layer.start(time, note, channel, pattern, kit, this);
-      }.bind(this));
+      });
     }
   },
 
   stop: function (time, note, channel, pattern, kit) {
-    this.layers.each(function (layer) {
+    this.layers.each(layer => {
       layer.stop(time, note, channel, pattern, kit, this);
-    }.bind(this));
+    });
   }
 
 }, overloadedAccessor('layer', Layer), sampleShortcut, connectable);

--- a/lib/effects/Chorus.js
+++ b/lib/effects/Chorus.js
@@ -1,5 +1,5 @@
-var Effect = require('../Effect');
-var numberInRangeType = require('../types/numberInRange');
+const Effect = require('../Effect');
+const numberInRangeType = require('../types/numberInRange');
 
 module.exports = Effect.extend({
 
@@ -21,12 +21,12 @@ module.exports = Effect.extend({
 
   createNode: function () {
 
-    var input = this.context.createGain();
-    var dry = input._dry = this.context.createGain();
-    var wet = input._wet = this.context.createGain();
-    var chorus = input._chorus = new this.tuna.Chorus();
+    const input = this.context.createGain();
+    const dry = input._dry = this.context.createGain();
+    const wet = input._wet = this.context.createGain();
+    const chorus = input._chorus = new this.tuna.Chorus();
     chorus.activate(true);
-    var output = input._output = this.context.createGain();
+    const output = input._output = this.context.createGain();
 
     input.connect(dry);
     dry.connect(output);
@@ -38,15 +38,15 @@ module.exports = Effect.extend({
     return this.combineNodes(input, output);
   },
 
-  configureNode: function (node) {
+  configureNode: function({_dry, _wet, _chorus, _output}) {
 
-    node._dry.gain.value = this.dry / 100;
+    _dry.gain.value = this.dry / 100;
 
-    node._wet.gain.value = this.wet / 100;
-    node._chorus.rate = this.rate;
-    node._chorus.feedback = this.feedback;
-    node._chorus.delay = this.delay;
+    _wet.gain.value = this.wet / 100;
+    _chorus.rate = this.rate;
+    _chorus.feedback = this.feedback;
+    _chorus.delay = this.delay;
 
-    node._output.gain.value = this.gain / 100;
+    _output.gain.value = this.gain / 100;
   }
 });

--- a/lib/effects/Compressor.js
+++ b/lib/effects/Compressor.js
@@ -1,5 +1,5 @@
-var Effect = require('../Effect');
-var numberInRangeType = require('../types/numberInRange');
+const Effect = require('../Effect');
+const numberInRangeType = require('../types/numberInRange');
 
 module.exports = Effect.extend({
 
@@ -22,8 +22,8 @@ module.exports = Effect.extend({
   },
 
   createNode: function () {
-    var node = this.context.createDynamicsCompressor();
-    var output = node._output = this.context.createGain();
+    const node = this.context.createDynamicsCompressor();
+    const output = node._output = this.context.createGain();
     node.connect(output);
     return this.combineNodes(node, output);
   },

--- a/lib/effects/Delay.js
+++ b/lib/effects/Delay.js
@@ -1,6 +1,6 @@
-var Effect = require('../Effect');
-var delay = require('soundbank-delay');
-var numberInRangeType = require('../types/numberInRange');
+const Effect = require('../Effect');
+const delay = require('soundbank-delay');
+const numberInRangeType = require('../types/numberInRange');
 
 module.exports = Effect.extend({
 

--- a/lib/effects/Filter.js
+++ b/lib/effects/Filter.js
@@ -1,5 +1,5 @@
-var Effect = require('../Effect');
-var numberInRangeType = require('../types/numberInRange');
+const Effect = require('../Effect');
+const numberInRangeType = require('../types/numberInRange');
 
 module.exports = Effect.extend({
 
@@ -26,11 +26,11 @@ module.exports = Effect.extend({
 
   createNode: function () {
 
-    var input = this.context.createGain();
-    var dry = input._dry = this.context.createGain();
-    var wet = input._wet = this.context.createGain();
-    var filter = input._filter = this.context.createBiquadFilter();
-    var output = input._output = this.context.createGain();
+    const input = this.context.createGain();
+    const dry = input._dry = this.context.createGain();
+    const wet = input._wet = this.context.createGain();
+    const filter = input._filter = this.context.createBiquadFilter();
+    const output = input._output = this.context.createGain();
 
     input.connect(dry);
     dry.connect(output);
@@ -42,16 +42,16 @@ module.exports = Effect.extend({
     return this.combineNodes(input, output);
   },
 
-  configureNode: function (node) {
+  configureNode: function({_dry, _wet, _filter, _output}) {
 
-    node._dry.gain.value = this.dry / 100;
+    _dry.gain.value = this.dry / 100;
 
-    node._wet.gain.value = this.wet / 100;
-    node._filter.type = this.shape;
-    node._filter.frequency.value = this.frequency;
-    node._filter.Q.value = this.q;
-    node._filter.gain.value = this.value / 12;
+    _wet.gain.value = this.wet / 100;
+    _filter.type = this.shape;
+    _filter.frequency.value = this.frequency;
+    _filter.Q.value = this.q;
+    _filter.gain.value = this.value / 12;
 
-    node._output.gain.value = this.gain / 100;
+    _output.gain.value = this.gain / 100;
   }
 });

--- a/lib/effects/Overdrive.js
+++ b/lib/effects/Overdrive.js
@@ -1,6 +1,6 @@
-var Effect = require('../Effect');
-var overdrive = require('soundbank-overdrive');
-var numberInRangeType = require('../types/numberInRange');
+const Effect = require('../Effect');
+const overdrive = require('soundbank-overdrive');
+const numberInRangeType = require('../types/numberInRange');
 
 module.exports = Effect.extend({
 
@@ -21,10 +21,10 @@ module.exports = Effect.extend({
 
   createNode: function () {
 
-    var input = this.context.createGain();
-    var dry = input._dry = this.context.createGain();
-    var _overdrive = input._overdrive = overdrive(this.context);
-    var output = input._output = this.context.createGain();
+    const input = this.context.createGain();
+    const dry = input._dry = this.context.createGain();
+    const _overdrive = input._overdrive = overdrive(this.context);
+    const output = input._output = this.context.createGain();
 
     input.connect(dry);
     dry.connect(output);
@@ -35,15 +35,15 @@ module.exports = Effect.extend({
     return this.combineNodes(input, output);
   },
 
-  configureNode: function (node) {
+  configureNode: function({_dry, _overdrive, _output}) {
 
-    node._dry.gain.value = this.dry / 100;
+    _dry.gain.value = this.dry / 100;
 
-    node._overdrive.gain.value = this.wet / 100;
-    node._overdrive.preBand.value = this.preBand / 100;
-    node._overdrive.color.value = this.color;
-    node._overdrive.postCut.value = this.postCut;
+    _overdrive.gain.value = this.wet / 100;
+    _overdrive.preBand.value = this.preBand / 100;
+    _overdrive.color.value = this.color;
+    _overdrive.postCut.value = this.postCut;
 
-    node._output.gain.value = this.gain / 100;
+    _output.gain.value = this.gain / 100;
   }
 });

--- a/lib/effects/Phaser.js
+++ b/lib/effects/Phaser.js
@@ -1,5 +1,5 @@
-var Effect = require('../Effect');
-var numberInRangeType = require('../types/numberInRange');
+const Effect = require('../Effect');
+const numberInRangeType = require('../types/numberInRange');
 
 module.exports = Effect.extend({
 
@@ -25,12 +25,12 @@ module.exports = Effect.extend({
 
   createNode: function () {
 
-    var input = this.context.createGain();
-    var dry = input._dry = this.context.createGain();
-    var wet = input._wet = this.context.createGain();
-    var phaser = input._phaser = new this.tuna.Phaser();
+    const input = this.context.createGain();
+    const dry = input._dry = this.context.createGain();
+    const wet = input._wet = this.context.createGain();
+    const phaser = input._phaser = new this.tuna.Phaser();
     phaser.activate(true);
-    var output = input._output = this.context.createGain();
+    const output = input._output = this.context.createGain();
 
     input.connect(dry);
     dry.connect(output);
@@ -42,17 +42,17 @@ module.exports = Effect.extend({
     return this.combineNodes(input, output);
   },
 
-  configureNode: function (node) {
+  configureNode: function({_dry, _wet, _phaser, _output}) {
 
-    node._dry.gain.value = this.dry / 100;
+    _dry.gain.value = this.dry / 100;
 
-    node._wet.gain.value = this.wet / 100;
-    node._phaser.rate = this.rate;
-    node._phaser.depth = this.depth;
-    node._phaser.feedback = this.feedback;
-    node._phaser.stereoPhase = this.stereoPhase;
-    node._phaser.baseModulationFrequency = this.modulationFrequency;
+    _wet.gain.value = this.wet / 100;
+    _phaser.rate = this.rate;
+    _phaser.depth = this.depth;
+    _phaser.feedback = this.feedback;
+    _phaser.stereoPhase = this.stereoPhase;
+    _phaser.baseModulationFrequency = this.modulationFrequency;
 
-    node._output.gain.value = this.gain / 100;
+    _output.gain.value = this.gain / 100;
   }
 });

--- a/lib/effects/PingPongDelay.js
+++ b/lib/effects/PingPongDelay.js
@@ -1,5 +1,5 @@
-var Effect = require('../Effect');
-var numberInRangeType = require('../types/numberInRange');
+const Effect = require('../Effect');
+const numberInRangeType = require('../types/numberInRange');
 
 module.exports = Effect.extend({
 
@@ -21,12 +21,12 @@ module.exports = Effect.extend({
 
   createNode: function () {
 
-    var input = this.context.createGain();
-    var dry = input._dry = this.context.createGain();
-    var wet = input._wet = this.context.createGain();
-    var pingpong = input._pingpong = new this.tuna.PingPongDelay();
+    const input = this.context.createGain();
+    const dry = input._dry = this.context.createGain();
+    const wet = input._wet = this.context.createGain();
+    const pingpong = input._pingpong = new this.tuna.PingPongDelay();
     pingpong.activate(true);
-    var output = input._output = this.context.createGain();
+    const output = input._output = this.context.createGain();
 
     input.connect(dry);
     dry.connect(output);
@@ -38,16 +38,16 @@ module.exports = Effect.extend({
     return this.combineNodes(input, output);
   },
 
-  configureNode: function (node) {
+  configureNode: function({_dry, _wet, _pingpong, _output}) {
 
-    node._dry.gain.value = this.dry / 100;
+    _dry.gain.value = this.dry / 100;
 
-    node._wet.gain.value = this.wet / 100;
-    node._pingpong.wetLevel = 1;
-    node._pingpong.feedback = this.feedback;
-    node._pingpong.delayTimeLeft = this.left * 1000;
-    node._pingpong.delayTimeRight = this.right * 1000;
+    _wet.gain.value = this.wet / 100;
+    _pingpong.wetLevel = 1;
+    _pingpong.feedback = this.feedback;
+    _pingpong.delayTimeLeft = this.left * 1000;
+    _pingpong.delayTimeRight = this.right * 1000;
 
-    node._output.gain.value = this.gain / 100;
+    _output.gain.value = this.gain / 100;
   }
 });

--- a/lib/effects/Reverb.js
+++ b/lib/effects/Reverb.js
@@ -1,5 +1,5 @@
-var Effect = require('../Effect');
-var reverb = require('soundbank-reverb');
+const Effect = require('../Effect');
+const reverb = require('soundbank-reverb');
 
 module.exports = Effect.extend({
 

--- a/lib/mixins/bypassable.js
+++ b/lib/mixins/bypassable.js
@@ -1,4 +1,4 @@
-var types = [
+const types = [
   'compressor',
   'delay',
   'filter',
@@ -19,9 +19,7 @@ module.exports = {
           return { val: newVal, type: 'bypassType' };
         }
         else if (Array.isArray(newVal)) {
-          var invalid = !!newVal.filter(function (possibleType) {
-            return !~types.indexOf(possibleType);
-          }).length;
+          const invalid = !!newVal.filter(possibleType => !~types.indexOf(possibleType)).length;
           if (invalid) {
             return { val: newVal, type: typeof newVal };
           }

--- a/lib/mixins/connectable.js
+++ b/lib/mixins/connectable.js
@@ -1,7 +1,7 @@
 module.exports = {
 
   props: {
-    connections: ['array', true, function () { return []; }]
+    connections: ['array', true, () => []]
   },
 
   connect: function (node) {
@@ -11,14 +11,10 @@ module.exports = {
 
   disconnect: function (node) {
     if (Array.isArray(node)) {
-      this.connections = this.connections.filter(function (connection) {
-        return !~node.indexOf(connection);
-      });
+      this.connections = this.connections.filter(connection => !~node.indexOf(connection));
     }
     else if (node) {
-      this.connections = this.connections.filter(function (connection) {
-        return node !== connection;
-      });
+      this.connections = this.connections.filter(connection => node !== connection);
     }
     else {
       this.connections = [];

--- a/lib/mixins/oscillatorParams.js
+++ b/lib/mixins/oscillatorParams.js
@@ -1,4 +1,4 @@
-var numberInRangeType = require('../types/numberInRange');
+const numberInRangeType = require('../types/numberInRange');
 
 module.exports = {
 

--- a/lib/mixins/overloadedAccessor.js
+++ b/lib/mixins/overloadedAccessor.js
@@ -1,11 +1,11 @@
 function overloadedAccessor (name, Ctor) {
 
-  var mixin = {};
+  const mixin = {};
 
   mixin[name] = function (id, model) {
 
-    var chained = false;
-    var collection = this[name + 's'];
+    let chained = false;
+    const collection = this[`${name}s`];
     if (!model && id instanceof Ctor) {
       model = id;
       model.id = collection.nextId();

--- a/lib/mixins/sampleParams.js
+++ b/lib/mixins/sampleParams.js
@@ -1,5 +1,5 @@
 
-var numberInRangeType = require('../types/numberInRange');
+const numberInRangeType = require('../types/numberInRange');
 
 module.exports = {
 

--- a/lib/mixins/sampleShortcut.js
+++ b/lib/mixins/sampleShortcut.js
@@ -1,4 +1,4 @@
-var Sample = require('../Sample');
+const Sample = require('../Sample');
 
 module.exports = {
 
@@ -13,7 +13,7 @@ module.exports = {
     if (typeof src === 'string') {
       params = params || {};
       params.src = src;
-      var sample = new this._sampleConstructor(params);
+      const sample = new this._sampleConstructor(params);
       this.layers.add(sample);
       return this;
     }

--- a/lib/mixins/triggerParams.js
+++ b/lib/mixins/triggerParams.js
@@ -1,4 +1,4 @@
-var numberInRangeType = require('../types/numberInRange');
+const numberInRangeType = require('../types/numberInRange');
 
 module.exports = {
 

--- a/lib/mixins/volumeParams.js
+++ b/lib/mixins/volumeParams.js
@@ -1,4 +1,4 @@
-var numberInRangeType = require('../types/numberInRange');
+const numberInRangeType = require('../types/numberInRange');
 
 module.exports = {
 

--- a/lib/types/instanceOf.js
+++ b/lib/types/instanceOf.js
@@ -16,7 +16,7 @@ function instanceOf (type, Constructor) {
       }
     },
     compare: function (currentVal, newVal, attributeName) {
-      var isSame = currentVal === newVal;
+      const isSame = currentVal === newVal;
       if (!isSame) {
         if (currentVal) {
           this.stopListening(currentVal);

--- a/lib/types/instanceOfType.js
+++ b/lib/types/instanceOfType.js
@@ -16,7 +16,7 @@ function instanceOfType (type, types) {
       }
     },
     compare: function (currentVal, newVal, attributeName) {
-      var isSame = currentVal === newVal;
+      const isSame = currentVal === newVal;
       if (!isSame) {
         if (currentVal) {
           this.stopListening(currentVal);

--- a/lib/utils/context.js
+++ b/lib/utils/context.js
@@ -1,4 +1,4 @@
-var audioContext = require('audio-context');
+let audioContext = require('audio-context');
 
 module.exports = {
   set: function (newContext) {

--- a/lib/utils/performanceTimePolyfill.js
+++ b/lib/utils/performanceTimePolyfill.js
@@ -9,19 +9,18 @@
 // if you want values similar to what you'd get with real perf.now, place this towards the head of the page
 // but in reality, you're just getting the delta between now() calls, so it's not terribly important where it's placed
 
-module.exports = function () {
+module.exports = () => {
 
   if ("performance" in global === false) {
       global.performance = {};
   }
 
-  Date.now = (Date.now || function () {  // thanks IE8
-	  return new Date().getTime();
-  });
+  Date.now = (Date.now || (() => // thanks IE8
+  new Date().getTime()));
 
   if ("now" in global.performance === false){
 
-    var nowOffset = Date.now();
+    let nowOffset = Date.now();
 
     if (performance.timing && performance.timing.navigationStart){
       nowOffset = performance.timing.navigationStart;

--- a/lib/utils/sequenceActions.js
+++ b/lib/utils/sequenceActions.js
@@ -2,7 +2,7 @@ module.exports = {
 
   then: function (base, rest) {
     rest = [].slice.call(rest);
-    return [base].concat(rest).map(function (row) {
+    return [base].concat(rest).map(row => {
       if (!Array.isArray(row)) {
         row = [row];
       }
@@ -12,7 +12,7 @@ module.exports = {
 
   after: function (base, rest) {
     rest = [].slice.call(rest);
-    return rest.concat(base).map(function (row) {
+    return rest.concat(base).map(row => {
       if (!Array.isArray(row)) {
         row = [row];
       }
@@ -22,13 +22,13 @@ module.exports = {
 
   and: function (base, rest) {
     rest = [].slice.call(rest);
-    var sequences = [base];
+    const sequences = [base];
     function add (sequence) {
       if (!~sequences.indexOf(sequence)) {
         sequences.push(sequence);
       }
     }
-    rest.forEach(function (candidate) {
+    rest.forEach(candidate => {
       if (Array.isArray(candidate)) {
         candidate.forEach(add);
       }

--- a/lib/utils/uniqueId.js
+++ b/lib/utils/uniqueId.js
@@ -1,8 +1,8 @@
-var counts = {};
+const counts = {};
 
 function uniqueId (prefix) {
   counts[prefix] = counts[prefix] || 0;
-  return prefix + '-' + (++counts[prefix]);
+  return `${prefix}-${++counts[prefix]}`;
 }
 
 module.exports = uniqueId;

--- a/lib/utils/vent.js
+++ b/lib/utils/vent.js
@@ -1,5 +1,5 @@
-var State = require('ampersand-state');
-var vent = null;
+const State = require('ampersand-state');
+let vent = null;
 
 function reset () {
   vent = new (State.extend())();

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "codeclimate-test-reporter": "0.0.4",
     "in-publish": "1.1.1",
     "istanbul": "0.3.13",
-    "jshint": "2.6.3",
+    "jshint": "2.9.4",
     "karma": "0.12.31",
     "karma-browserify": "4.1.2",
     "karma-chrome-launcher": "0.1.8",


### PR DESCRIPTION
Hej Adam,

this is the result of the applied transforms:
* `arrow` (afterwards changed the `Tuna` mock back)
* `class` (ineffective, as you're using a `Model.extend` approach)
* `let` (I guess the most useful one)
* `template`
* `default-param`
* `destruct-param`
* `for-of` (couldn't transform few occasions)
* `for-each` (didn't change anything)

JSHint was updated to support `esversion: 6`
Linting & tests are running, didn't test anything manually.

How far do you want to push this? 
Cannot promise to spend more time on this. But I think it makes sense to at least refactor further to `class` syntax, as you're effectively already using a fake class-based approach.
Maybe use ESLint to apply a few more fixes, in case you do not like the code style (e.g. I prefer brackets around single fat-arrow parameters)

When done, it closes #55 